### PR TITLE
コマンドが長すぎるとレイアウトが崩れるのを修正 #182

### DIFF
--- a/websh_front/src/index.nim
+++ b/websh_front/src/index.nim
@@ -219,7 +219,8 @@ proc createDom(): VNode =
                     text "Clear history"
                 for hist in shellHistory:
                   tdiv:
-                    text hist
+                    textarea(class = "textarea is-success", rows = "2", readonly="readonly"):
+                      text hist
       tdiv(class = "column"):
         tdiv(class = "tile is-ancestor"):
           tdiv(class = "tile is-parent is-vertical"):


### PR DESCRIPTION
closes #182 

ホントはヒストリを閉じられるようにしたかったんだけれど、
なぜかたまにボタンが反応しなくなって、ヒストリを閉じられなくなる。
なぜ。Karax何もわからない